### PR TITLE
files for kafka connect and debezium CDC for postgres connector

### DIFF
--- a/environments/kafkaconnect/base/KafkaConnectPostgres_Dockerfile
+++ b/environments/kafkaconnect/base/KafkaConnectPostgres_Dockerfile
@@ -1,0 +1,13 @@
+# This Dockerfile expects the Debezium CDC for Postgres connector binaries and the Apicurio Schema Registry and the Avro protocol binaries
+# These are expected to be placed in the ./connectors/ folder
+# All binaries can be dowloaded as part of two packages from Maven
+# The Debezium CDC for Postgres connector binaries can be found in https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/
+# The Apicurio Schema Registry and the Avro protocol binaries can be found in https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/
+# Download the latest debezium-connector-postgres-X.Y.Z.Final-plugin.tar.gz and apicurio-registry-distro-connect-converter-X.Y.Z.Final-converter.tar.gz respectively
+# Untar both files and place all its jars in the ./connectors/ folder
+# Finally, build the image --> docker build -f KafkaConnectPostgres_Dockerfile -t quay.io/ibmcase/kafka-connect-postgres .
+
+FROM quay.io/strimzi/kafka:0.22.0-kafka-2.7.0
+USER root:root
+COPY ./connectors/ /opt/kafka/plugins/
+USER 1001

--- a/environments/kafkaconnect/base/KafkaConnectPostgres_Dockerfile
+++ b/environments/kafkaconnect/base/KafkaConnectPostgres_Dockerfile
@@ -6,8 +6,8 @@
 
 FROM quay.io/strimzi/kafka:0.22.0-kafka-2.7.0
 
-ARG DEBEZIUM_CDC_POSTGRES_VERSION=1.5.0.Final
-ARG APICURIO_AND_AVRO_VERSION=2.0.0.Final
+ARG DEBEZIUM_CDC_POSTGRES_VERSION=1.4.1.Final
+ARG APICURIO_AND_AVRO_VERSION=1.3.2.Final
 
 USER root:root
 
@@ -16,11 +16,11 @@ RUN mkdir /tmp/apicurio_avro && \
     mkdir -p /opt/kafka/plugins/debezium_cdc_postgres_connector
 
 ADD https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/${DEBEZIUM_CDC_POSTGRES_VERSION}/debezium-connector-postgres-${DEBEZIUM_CDC_POSTGRES_VERSION}-plugin.tar.gz /tmp/debezium_cdc_postgres_binaries
-ADD https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/${APICURIO_AND_AVRO_VERSION}/apicurio-registry-distro-connect-converter-${APICURIO_AND_AVRO_VERSION}.tar.gz /tmp/apicurio_avro
+ADD https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/${APICURIO_AND_AVRO_VERSION}/apicurio-registry-distro-connect-converter-${APICURIO_AND_AVRO_VERSION}-converter.tar.gz /tmp/apicurio_avro
 
 RUN tar -xvzf /tmp/debezium_cdc_postgres_binaries/debezium-connector-postgres-${DEBEZIUM_CDC_POSTGRES_VERSION}-plugin.tar.gz --directory /tmp/debezium_cdc_postgres_binaries/ && \
     cp /tmp/debezium_cdc_postgres_binaries/debezium-connector-postgres/*.jar /opt/kafka/plugins/debezium_cdc_postgres_connector && \
-    tar -xzf /tmp/apicurio_avro/apicurio-registry-distro-connect-converter-${APICURIO_AND_AVRO_VERSION}.tar.gz --directory /tmp/apicurio_avro/ && \
+    tar -xzf /tmp/apicurio_avro/apicurio-registry-distro-connect-converter-${APICURIO_AND_AVRO_VERSION}-converter.tar.gz --directory /tmp/apicurio_avro/ && \
     cp /tmp/apicurio_avro/*.jar /opt/kafka/plugins/debezium_cdc_postgres_connector
 
 USER 1001

--- a/environments/kafkaconnect/base/KafkaConnectPostgres_Dockerfile
+++ b/environments/kafkaconnect/base/KafkaConnectPostgres_Dockerfile
@@ -1,13 +1,27 @@
-# This Dockerfile expects the Debezium CDC for Postgres connector binaries and the Apicurio Schema Registry and the Avro protocol binaries
-# These are expected to be placed in the ./connectors/ folder
-# All binaries can be dowloaded as part of two packages from Maven
-# The Debezium CDC for Postgres connector binaries can be found in https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/
-# The Apicurio Schema Registry and the Avro protocol binaries can be found in https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/
-# Download the latest debezium-connector-postgres-X.Y.Z.Final-plugin.tar.gz and apicurio-registry-distro-connect-converter-X.Y.Z.Final-converter.tar.gz respectively
-# Untar both files and place all its jars in the ./connectors/ folder
-# Finally, build the image --> docker build -f KafkaConnectPostgres_Dockerfile -t quay.io/ibmcase/kafka-connect-postgres .
+# This Dockerfile builds a Kafka Docker image with the Debezium CDC for Postgres connector, the Apicurio Schema Registry and the Avro protocol binaries in it.
+# All binaries can be downloaded as part of two packages from Maven:
+# - The Debezium CDC for Postgres connector binaries can be found in https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/
+# - The Apicurio Schema Registry and the Avro protocol binaries can be found in https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/
+# To build the image: docker build -f KafkaConnectPostgres_Dockerfile -t quay.io/ibmcase/kafka-connect-postgres .
 
 FROM quay.io/strimzi/kafka:0.22.0-kafka-2.7.0
+
+ARG DEBEZIUM_CDC_POSTGRES_VERSION=1.5.0.Final
+ARG APICURIO_AND_AVRO_VERSION=2.0.0.Final
+
 USER root:root
-COPY ./connectors/ /opt/kafka/plugins/
+
+RUN mkdir /tmp/apicurio_avro && \
+    mkdir /tmp/debezium_cdc_postgres_binaries && \
+    mkdir -p /opt/kafka/plugins/debezium_cdc_postgres_connector
+
+ADD https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/${DEBEZIUM_CDC_POSTGRES_VERSION}/debezium-connector-postgres-${DEBEZIUM_CDC_POSTGRES_VERSION}-plugin.tar.gz /tmp/debezium_cdc_postgres_binaries
+ADD https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/${APICURIO_AND_AVRO_VERSION}/apicurio-registry-distro-connect-converter-${APICURIO_AND_AVRO_VERSION}.tar.gz /tmp/apicurio_avro
+
+RUN tar -xvzf /tmp/debezium_cdc_postgres_binaries/debezium-connector-postgres-${DEBEZIUM_CDC_POSTGRES_VERSION}-plugin.tar.gz --directory /tmp/debezium_cdc_postgres_binaries/ && \
+    cp /tmp/debezium_cdc_postgres_binaries/debezium-connector-postgres/*.jar /opt/kafka/plugins/debezium_cdc_postgres_connector && \
+    tar -xzf /tmp/apicurio_avro/apicurio-registry-distro-connect-converter-${APICURIO_AND_AVRO_VERSION}.tar.gz --directory /tmp/apicurio_avro/ && \
+    cp /tmp/apicurio_avro/*.jar /opt/kafka/plugins/debezium_cdc_postgres_connector
+
 USER 1001
+

--- a/environments/kafkaconnect/base/kafka-connect-strimzi.yaml
+++ b/environments/kafkaconnect/base/kafka-connect-strimzi.yaml
@@ -2,7 +2,6 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnect
 metadata:
   name: connect-cluster-<UNIQUE_ID>
-  namespace: vaccine-omo
   annotations:
     strimzi.io/use-connector-resources: "true"
 spec:

--- a/environments/kafkaconnect/base/kafka-connect-strimzi.yaml
+++ b/environments/kafkaconnect/base/kafka-connect-strimzi.yaml
@@ -1,0 +1,40 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaConnect
+metadata:
+  name: connect-cluster-<UNIQUE_ID>
+  namespace: vaccine-omo
+  annotations:
+    strimzi.io/use-connector-resources: "true"
+spec:
+  bootstrapServers: '<KAFKA_BOOTSTRAP_URL>'
+  image: quay.io/ibmcase/kafka-connect-postgres
+  authentication:
+    certificateAndKey:
+      certificate: user.crt
+      key: user.key
+      secretName: tls-user
+    type: tls
+  version: 2.7.0
+  tls:
+    trustedCertificates:
+      - secretName: kafka-cluster-ca-cert
+        certificate: ca.crt
+  replicas: 1
+  config:
+    group.id: connect-cluster-<UNIQUE_ID>
+    value.converter: org.apache.kafka.connect.json.JsonConverter
+    value.converter.schemas.enable: false
+    offset.storage.topic: connect-cluster-offsets-<UNIQUE_ID>
+    config.storage.topic: connect-cluster-configs-<UNIQUE_ID>
+    status.storage.topic: connect-cluster-status-<UNIQUE_ID>
+    config.storage.replication.factor: 3
+    offset.storage.replication.factor: 3
+    status.storage.replication.factor: 3
+    config.providers: file
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
+  tasksMax: 3
+  externalConfiguration:
+    volumes:
+      - name: postgres-connector
+        secret:
+          secretName: postgres-connector

--- a/environments/kafkaconnect/base/pg-connector-strimzi.yaml
+++ b/environments/kafkaconnect/base/pg-connector-strimzi.yaml
@@ -1,0 +1,32 @@
+apiVersion: kafka.strimzi.io/v1alpha1 
+kind: KafkaConnector 
+metadata: 
+  name: pg-connector-apicurio
+  labels: 
+    strimzi.io/cluster: connect-cluster-<UNIQUE_ID>
+spec: 
+  class: io.debezium.connector.postgresql.PostgresConnector
+  tasksMax: 1 
+  config:
+    database.dbname: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:database-dbname}"
+    database.hostname: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:database-hostname}"
+    database.password: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:database-password}"
+    database.port: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:database-port}"
+    database.server.name: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:database-server-name}"
+    database.user: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:database-user}"
+    table.whitelist: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:table-whitelist}"
+    plugin.name: pgoutput
+    key.converter: io.apicurio.registry.utils.converter.AvroConverter
+    key.converter.apicurio.registry.as-confluent: true
+    key.converter.apicurio.registry.url: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:schema-registry-url}"
+    key.converter.apicurio.registry.global-id: io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy
+    key.converter.apicurio.registry.request.ssl.truststore.location: "${file:/tmp/strimzi-connect.properties:ssl.truststore.location}"
+    key.converter.apicurio.registry.request.ssl.truststore.password: "${file:/tmp/strimzi-connect.properties:ssl.truststore.password}"
+    key.converter.apicurio.registry.request.ssl.truststore.type: "${file:/tmp/strimzi-connect.properties:ssl.truststore.type}"
+    value.converter: io.apicurio.registry.utils.converter.AvroConverter
+    value.converter.apicurio.registry.as-confluent: true
+    value.converter.apicurio.registry.url: "${file:/opt/kafka/external-configuration/postgres-connector/connector.properties:schema-registry-url}"
+    value.converter.apicurio.registry.global-id: io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy
+    value.converter.apicurio.registry.request.ssl.truststore.location: "${file:/tmp/strimzi-connect.properties:ssl.truststore.location}"
+    value.converter.apicurio.registry.request.ssl.truststore.password: "${file:/tmp/strimzi-connect.properties:ssl.truststore.password}"
+    value.converter.apicurio.registry.request.ssl.truststore.type: "${file:/tmp/strimzi-connect.properties:ssl.truststore.type}"


### PR DESCRIPTION
Adding the files needed for automating the deployment of a kafka connect cluster with the Debezium CDC for Postgres connector binaries in it as well as the creation of the corresponding connector for the Vaccine Order Management and Optimization use case.

Im also adding the Dockerfile I created for extending the base kafka image with the Debezium CDC for Postgres connector binaries in it. Image that we later on reference on the Kafka Connect deployment file.